### PR TITLE
feat: added auto toilet emoji for double dash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,13 +131,11 @@ dist
 
 .vscode/**
 .vscode-test/**
-src/**
 .gitignore
 .yarnrc
 vsc-extension-quickstart.md
 **/tsconfig.json
 **/eslint.config.mjs
 **/*.map
-**/*.ts
 **/.vscode-test.*
 *.vsix

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The following keywords are highlighted in Brainrot:
 | cooked     | auto         |
 | flex       | for          |
 | bussin     | return       |
-| edging     | if           |
+| edgy       | if           |
 | amogus     | else         |
 | goon       | while        |
 | bruh       | break        |
@@ -124,7 +124,6 @@ The following keywords are highlighted in Brainrot:
 | whopper    | extern       |
 | cringe     | goto         |
 | giga       | long         |
-| edgy       | register     |
 | soy        | short        |
 | nut        | signed       |
 | maxxing    | sizeof       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brainrot",
-  "version": "0.0.1",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainrot",
-      "version": "0.0.1",
+      "version": "0.0.7",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@types/mocha": "^10.0.9",
@@ -20,7 +20,7 @@
         "typescript": "^5.6.3"
       },
       "engines": {
-        "vscode": "^1.94.0"
+        "vscode": "^1.90.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -8,14 +8,16 @@
     "type": "git",
     "url": "https://github.com/araujo88/brainrot-vscode-support"
   },
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "vscode": "^1.90.0"
   },
   "categories": [
     "Programming Languages"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onLanguage:brainrot"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "languages": [
@@ -37,6 +39,12 @@
         "scopeName": "source.brainrot",
         "path": "./syntaxes/brainrot.tmLanguage.json"
       }
+    ],
+    "commands": [
+      {
+        "command": "brainrot.insertToiletEmoji",
+        "title": "Insert Toilet Emoji"
+      }
     ]
   },
   "scripts": {
@@ -45,7 +53,8 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "release": "standard-version"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.9",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,69 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+    let disposables: vscode.Disposable[] = [];
+
+    // Register the text document change handler
+    const changeHandler = vscode.workspace.onDidChangeTextDocument(async event => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || event.contentChanges.length === 0) {
+            return;
+        }
+
+        // Make sure we're in a brainrot language document
+        if (editor.document.languageId !== 'brainrot') {
+            return;
+        }
+
+        // Make sure the change happened in the active document
+        if (event.document.uri.toString() !== editor.document.uri.toString()) {
+            return;
+        }
+
+        const change = event.contentChanges[event.contentChanges.length - 1];
+        
+        // We only care about single-character insertions that are "/"
+        if (change.text !== '/' || change.rangeLength !== 0) {
+            return;
+        }
+
+        const lineText = editor.document.lineAt(change.range.start.line).text;
+        const position = change.range.start.character;
+
+        // Check if there's a slash right before our current position
+        if (position > 0 && lineText[position - 1] === '/') {
+            // Create a range that covers both slashes
+            const startPos = new vscode.Position(change.range.start.line, position - 1);
+            const endPos = new vscode.Position(change.range.start.line, position + 1);
+            const range = new vscode.Range(startPos, endPos);
+
+            try {
+                await editor.edit(editBuilder => {
+                    editBuilder.replace(range, '🚽');
+                }, {
+                    undoStopBefore: false,
+                    undoStopAfter: true
+                });
+            } catch (error) {
+                console.error('Failed to replace text:', error);
+            }
+        }
+    });
+    disposables.push(changeHandler);
+
+    // Register the insertToiletEmoji command
+    const command = vscode.commands.registerCommand('brainrot.insertToiletEmoji', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+            const position = editor.selection.active;
+            await editor.edit(editBuilder => {
+                editBuilder.insert(position, '🚽');
+            });
+        }
+    });
+    disposables.push(command);
+
+    context.subscriptions.push(...disposables);
+}
+
+export function deactivate() {}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,0 +1,84 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('Brainrot Extension Test Suite', () => {
+    vscode.window.showInformationMessage('Start all tests.');
+
+    async function createTestDocument(content: string): Promise<vscode.TextDocument> {
+        // Create an untitled document with the brainrot language
+        const document = await vscode.workspace.openTextDocument({
+            content: content,
+            language: 'brainrot'
+        });
+        await vscode.window.showTextDocument(document);
+        return document;
+    }
+
+    function delay(ms: number) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    test('Inserts toilet emoji after typing "//"', async () => {
+        const document = await createTestDocument('');
+        const editor = await vscode.window.showTextDocument(document);
+
+        // Type the first slash
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(0, 0), '/');
+        });
+
+        await delay(100);
+
+        // Type the second slash
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(0, 1), '/');
+        });
+
+        await delay(300);
+
+        const text = document.getText();
+        assert.strictEqual(
+            text,
+            '🚽',
+            `Toilet emoji should be inserted after typing "//". Actual: "${text}"`
+        );
+    });
+
+    test('Does not insert emoji if "//" is in the middle of text', async () => {
+        const document = await createTestDocument('Hello // world');
+        const editor = await vscode.window.showTextDocument(document);
+
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(0, 14), '/');
+        });
+
+        await delay(300);
+
+        const text = document.getText();
+        assert.strictEqual(
+            text,
+            'Hello // world/',
+            `No emoji should be inserted in the middle of text. Actual: "${text}"`
+        );
+    });
+
+    test('Inserts emoji at the correct position', async () => {
+        const document = await createTestDocument('First /');
+        const editor = await vscode.window.showTextDocument(document);
+
+        await delay(100);
+
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(0, 7), '/');
+        });
+
+        await delay(300);
+
+        const text = document.getText();
+        assert.strictEqual(
+            text,
+            'First 🚽',
+            `Toilet emoji should be inserted at the correct position. Actual: "${text}"`
+        );
+    });
+});

--- a/syntaxes/brainrot.tmLanguage.json
+++ b/syntaxes/brainrot.tmLanguage.json
@@ -3,7 +3,7 @@
     "scopeName": "source.brainrot",
     "patterns": [
       {
-        "match": "\\b(skibidi|rizz|flex|bussin|edging|amogus|goon|bruh|grind|chad|gigachad|yap|grimace|sigma rule|based|mewing|gyatt|whopper|cringe|giga|edgy|soy|nut|maxxing|salty|gang|ohio|chungus|nonut|schizo|cap|yes|no)\\b",
+        "match": "\\b(skibidi|rizz|flex|bussin|amogus|goon|bruh|grind|chad|gigachad|yap|grimace|sigma rule|based|mewing|gyatt|whopper|cringe|giga|edgy|soy|nut|maxxing|salty|gang|ohio|chungus|nonut|schizo|cap|yes|no)\\b",
         "name": "keyword.control.brainrot"
       },
       {
@@ -43,7 +43,7 @@
           "patterns": [
             {
               "name": "comment.line.double-slash.brainrot",
-              "match": "//.*$"
+              "match": "🚽.*$"
             }
           ]
         },


### PR DESCRIPTION
Type `//` to add a single-line comment to `.brainrot` file in the form of a toilet emoji (🚽).

![adding comments](https://github.com/user-attachments/assets/f26be495-e3ae-4bb9-bd7d-ba14e25bce6d)
